### PR TITLE
feat: build complete home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,123 @@
-import Container  from "@/components/layout/Container";
+import ButtonLink from "@/components/ui/ButtonLink";
+import Section from "@/components/ui/Section";
+import ProjectCard from "@/components/ui/ProjectCard";
+import Container from "@/components/layout/Container";
+import { featuredProjects } from "@/data/projects";
 
 export default function HomePage() {
   return (
-    <Container className="py-16">
-      <h1 className="text-3xl font-semibold tracking-tight">
-        Tester QA - QA Manual con base en desarrollo web y automatización en formación
-      </h1>
-      <p className="mt-4 text-black/70">
-      Especializado en validación funcional de productos web, con enfoque en calidad, claridad y mejora continua.
-      </p>
-    </Container>
+    <>
+      {/* HERO: primera impresión para RRHH (mensaje claro, directo y QA-first) */}
+      <section className="py-16 sm:py-20">
+        <Container>
+          <h1 className="text-3xl sm:4xl font-semibold tracking-tight max-w-3xl">
+            Tester QA - QA Manual con base en desarrollo web y automatización en formación
+          </h1>
+
+          <p className="mt-4 text-black/70 max-w-2xl">
+          Especiaizado en validación funcional de productos web, con enfoque en calidad, claridad y mejora continua.
+          </p>
+
+          {/* Bullets de valor: "escaneables" para RRHH */}
+          <ul className="mt-6 space-y-2 text-black/80">
+            <li>• Testing funcional de aplicaciones web y APIs.</li>
+            <li>• Documentación de calidad: casos de prueba, matrices y evidencias.</li>
+            <li>• Enfoque en detección temprana de errores y mejora continua.</li>
+          </ul>
+
+          {/* CTA principal: el primer clic debe llevar a evidencia (Proyectos) */}
+          <div className="mt-8 flex flex-wrap gap-3">
+            <ButtonLink href="/projects" variant="primary">Ver proyectos</ButtonLink>
+            {/* CTA secundario: reduce fricción y salida rápida para contacto */}
+            <ButtonLink href="/contact" variant="secondary">Contacto</ButtonLink>
+          </div>
+        </Container>
+      </section>
+
+      {/* Resumen profesional: corto, orientado a valor (sin saturar de tecnología) */}
+      <Section 
+        title="Resumen profesional"
+        subtitle="Mi enfoque es asegurar la calidad de productos web con pruebas funcionales, documentación clara y comunicación efectiva con desarrollo.">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-2xl border border-black/10 p-5">
+              <h3 className="font-semibold">Testing funcional</h3>
+              <p className="mt-2 text-sm text-black/70">
+                Validación de flujos criticos (formularios, autenticación, CRUD, reglas de negocio) y criterios de aceptación.
+              </p>
+            </div>
+
+            <div className="rounded-2xl border border-black/10 p-5">
+              <h3 className="font-semibold">APIs</h3>
+              <p className="mt-2 text-sm text-black/70">
+                Pruebas de endpoints, verificación de respuestas, manejo de errores y documentación de evidencias.
+              </p>
+            </div>
+
+            <div className="rounded-2xl border border-black/10 p-5">
+              <h3 className="font-semibold">Automatización</h3>
+              <p className="mt-2 text-sm text-black/70">
+                Enfoque progesivo: primero pruebas manuales solidas, luego automatización estable y mantenible.
+              </p>
+            </div>
+          </div>
+        </Section>
+
+        {/* Proyectos destacados: evidencia rápida (2-3 tarjetas) */}
+        <Section
+          title="Proyectos destacados"
+          subtitle="Una selección breve para mostrar evidencia práctica. Cada proyecto incluye enfoque, documentación y aprendizajes.">
+            <div className="grid gap-4 md:grid-cols-3">
+              {featuredProjects.map((p) => (
+                <ProjectCard key={p.slug} project={p} />
+              ))}
+            </div>
+
+            <div className="mt-8">
+              <ButtonLink href="/projects" variant="secondary">Ver todos los proyectos</ButtonLink>
+            </div>
+          </Section>
+
+          {/* QA & Metodología (preview): refuerza "cómo trabajo" sin abrumar a RRHH */}
+          <Section
+            title="QA & Metodología"
+            subtitle="Cómo organizo pruebas, documento resultados y reporto bugs de manera clara">
+              <div className="grid gap-4 sm:grid-cols-3">
+                <div className="rounded-2xl border border-black/10 p-5">
+                  <h3 className="font-semibold">Estrategia</h3>
+                  <p className="mt-2 text-sm text-black/70">
+                    Priorizo flujos criticos, smoke/regression y criterios de aceptación para maximizar cobertura con foco.
+                  </p>
+                </div>
+
+                <div className="rounded-2xl border border-black/10 p-5">
+                  <h3 className="font-semibold">Documentación</h3>
+                  <p className="mt-2 text-sm text-black/70">
+                    Casos de prueba, matrices y evidencias (pasos reproducibles, resultados esperados vs. reales).
+                  </p>
+                </div>
+
+                <div className="rounded-2xl border border-black/10 p-5">
+                  <h3 className="font-semibold">Reporte de bugs</h3>
+                  <p className="mt-2 text-sm text-black/70">
+                    Reportes claros: pasos, entorno, severidad, evidencia (capturas) y contexto para facilitar el fix.
+                  </p>
+                </div>
+
+                <div className="mt-8">
+                  <ButtonLink href="/qa" variant="secondary">Ver metodología completa</ButtonLink>
+                </div>
+              </div>
+            </Section>
+
+            {/* CTA final: llamada a acción sin fricción */}
+            <Section 
+              title="¿Hablamos?"
+              subtitle="Estoy disponible para oportunidades remotas en QA Manual. Puedes contactarme o descargar mi CV.">
+                <div className="flex flex-wrap gap-3">
+                  <ButtonLink href="/contact" variant="primary">Contavtarme</ButtonLink>
+                  <ButtonLink href="/cv" variant="secondary">Ver CV</ButtonLink>
+                </div>
+              </Section>
+    </>
   );
 }

--- a/src/components/ui/ButtonLink.tsx
+++ b/src/components/ui/ButtonLink.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+// Botón basado en Link para navegación interna.
+// Mantiene un estilo consistente para CTAs ("ver proyectos", "Contactar", etc.)
+type Props = {
+    href: string;
+    children: React.ReactNode;
+    variant?: "primary" | "secondary";
+};
+
+export default function ButtonLink({ href, children, variant = "primary" }: Props) {
+    const base = 
+        "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition";
+    const styles = 
+        variant === "primary"
+            ? "bg-black text-white hover:bg-black/90"
+            : "border border-black/15 bg-white hover:bg-black/5";
+
+    return (
+        <Link href={href} className="{`${base} ${styles}`}">
+            {children}
+        </Link>
+    );
+}

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import Tag from "@/components/ui/Tag";
+import type { Project } from "@/data/projects";
+
+// Tarjeta de proyecto: titulo, resumen y tags.
+// Importante: la tarjeta linkea al detalle (/projects/[slug]) para reforzar la narrativa QA.
+type Props = { project: Project };
+
+export default function ProjectCard({ project }: Props) {
+    return (
+        <article className="rounded-2xl border border-black/10 bg-white p-5 shadow-sm">
+            <h3 className="text-base font-semibold tracking-tight">
+                <Link href={`/projects/${project.slug}`} className="hover:underline underline-offset-4">
+                {project.title}
+                </Link>
+            </h3>
+
+            <p className="mt-2 text-sm text-black/70">
+                {project.summary}
+            </p>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+                {project.tags.map((t) => (
+                    <Tag key={t} label={t} />
+                ))}
+            </div>
+        </article>
+    );
+}

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import Container from "@/components/layout/Container";
+
+// Componente de sección para mantener espacios y jerarquia visual consistentes.
+// Esto evita repetir "pading/margins" en todas las paginas.
+type Props = {
+    title?: string;
+    subtitle?: string;
+    children: ReactNode;
+};
+
+export default function Section({ title, subtitle, children }: Props) {
+    return (
+        <section className="py-12 sm:py-16">
+            <Container>
+                {(title || subtitle) && (
+                    <header className="mb-6 sm:mb-8">
+                        {title && (
+                            <h2 className="text-xl sm:text-2xl font-semibold tracking-tight">
+                                {title}
+                            </h2>
+                        )}
+                        {subtitle && (
+                            <p className="mt-2 text-black/70 max-w-2xl">
+                                {subtitle}
+                            </p>
+                        )}
+                    </header>
+                )}
+                {children}
+            </Container>
+        </section>
+    );
+}

--- a/src/components/ui/Tag.tsx
+++ b/src/components/ui/Tag.tsx
@@ -1,0 +1,11 @@
+// Pequeña etiqueta visual para mostrar tecnologias/enfoques.
+// En QA ayuda a "escanear" rápidamente el tipo de proyecto.
+type Props = { label: string };
+
+export default function Tag({ label}: Props) {
+    return (
+        <span className="inline-flex items-center rounded-full border border-black/10 px-2.5 py-1 text-xs text-black/70">
+            {label}
+        </span>
+    );
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,43 @@
+// src/data/projects.ts
+// Este archivo centraliza los datos de proyectos para que el portafolio sea mantenible.
+// En vez de "hardcodear" en la UI, definimos datos aqui y la Home solo los renderiza.
+
+export type Project = {
+    slug: string;
+    title: string;
+    summary: string;
+    tags: string[];
+    // Links opcionales (más adelante los completare con demo y repo)
+    repoUrl?: string;
+    demoUrl?: string;
+};
+
+// NOTA: Por ahora son placeholders. En cuanto tenga proyectos reales, reemplazo esto.
+// Mantener los slugs consistentes me permite crear páginas /projects/[slug] sin romper enlaces.
+
+export const projects: Project[] = [
+    {
+        slug: "app-qa-lab",
+        title: "App QA Lab (Sistema bajo prueba)",
+        summary:
+            "Aplicación web creada para practicar testing funcional (web + APIs) y automatizaciones en formación",
+        tags: ["QA Manual", "web", "APIs", "Automatización"],
+    },
+    {
+        slug: "api-testing-samples",
+        title: "API Testing Samples",
+        summary: 
+            "Colección de casos de prueba y validaciones para endpoints (contratos, errores, status codes)",
+        tags: ["APIs", "Testing", "Documentación"],
+    },
+    {
+        slug: "automation-learning",
+        title: "Automatización (en formación)",
+        summary: 
+            "Evidencias progresiva de automatización: criterios de selección, estabilidad, reportes y buenas prácticas.",
+        tags: ["Automatización", "Aprendizaje"], 
+    },
+];
+
+// En Home mostrare solo algunos proyectos como "destacados".
+export const featuredProjects = projects.slice(0, 3);


### PR DESCRIPTION
## ¿Qué se hizo?
Se implementó la página **Home** del portafolio, siguiendo una estructura orientada a RRHH y enfocada en QA Manual.

## Cambios principales
- Hero con mensaje QA-first y CTA principal hacia Proyectos
- Sección de resumen profesional
- Proyectos destacados (datos centralizados y tarjetas reutilizables)
- Preview de QA & Metodología
- CTA final hacia Contacto y CV
- Componentes UI reutilizables y código comentado en español

## ¿Por qué?
La Home es el primer punto de contacto del portafolio. Esta implementación prioriza:
- Claridad del mensaje
- Evidencia rápida (proyectos)
- Navegación simple y mantenible

## Cómo probar
1. Ejecutar `npm run dev`
2. Abrir `http://localhost:3000`
3. Verificar navegación del menú y CTAs

## Issue relacionado
Closes #4